### PR TITLE
Now supports `content-encoding: identity` (closes #13)

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,13 +12,13 @@ function inflate(stream, options) {
 
   var encoding = options.encoding
     || (stream.headers && stream.headers['content-encoding'])
-    || ''
+    || 'identity'
 
   switch (encoding) {
   case 'gzip':
   case 'deflate':
     break
-  case '':
+  case 'identity':
     return stream
   default:
     var err = new Error('Unsupported Content-Encoding: ' + encoding)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "inflation",
   "description": "Easily unzip an HTTP stream",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "author": "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)",
   "license": "MIT",
   "repository": "stream-utils/inflation",

--- a/test/test.js
+++ b/test/test.js
@@ -28,11 +28,19 @@ describe('inflate(stream, options)', function () {
     assertBuffer(inflation(stream, opts), string, done)
   })
 
+  it('should pass-through identity streams', function (done) {
+    var stream = createStream(new Buffer('identity!', 'utf-8'))
+    var string = 'identity!'
+    stream.headers = {}
+    assertBuffer(inflation(stream), string, done)
+  })
+
   describe('stream with headers', function () {
+
     it('should pass-through identity streams', function (done) {
       var stream = createStream(new Buffer('identity!', 'utf-8'))
       var string = 'identity!'
-      stream.headers = {}
+      stream.headers = {'content-encoding': 'identity'}
       assertBuffer(inflation(stream), string, done)
     })
 


### PR DESCRIPTION
Addresses issue #13.  Added a new test for it, and all tests pass.