### PR TITLE
feat: now supports 'content-encoding:utf-8' (closes #16)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 var zlib = require('zlib')
 
 module.exports = inflate
@@ -11,19 +10,22 @@ function inflate(stream, options) {
   options = options || {}
 
   var encoding = options.encoding
-    || (stream.headers && stream.headers['content-encoding'])
+    || (stream.headers && stream.headers[ 'content-encoding' ])
     || 'identity'
 
+  encoding = encoding.toLowerCase()
+
   switch (encoding) {
-  case 'gzip':
-  case 'deflate':
-    break
-  case 'identity':
-    return stream
-  default:
-    var err = new Error('Unsupported Content-Encoding: ' + encoding)
-    err.status = 415
-    throw err
+    case 'gzip':
+    case 'deflate':
+      break
+    case 'identity':
+    case 'utf-8':
+      return stream
+    default:
+      var err    = new Error('Unsupported Content-Encoding: ' + encoding)
+      err.status = 415
+      throw err
   }
 
   // no not pass-through encoding

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "inflation",
   "description": "Easily unzip an HTTP stream",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)",
   "license": "MIT",
   "repository": "stream-utils/inflation",

--- a/test/test.js
+++ b/test/test.js
@@ -44,6 +44,13 @@ describe('inflate(stream, options)', function () {
       assertBuffer(inflation(stream), string, done)
     })
 
+    it('should pass-through utf-8 streams', function (done) {
+      var stream = createStream(new Buffer('identity!', 'utf-8'))
+      var string = 'identity!'
+      stream.headers = {'content-encoding': 'utf-8'}
+      assertBuffer(inflation(stream), string, done)
+    })
+
     it('should inflate gzip streams', function (done) {
       var stream = createStream(new Buffer('1f8b080000000000000b4bcecf2d284a2d2e4e4d510400fb94f3640b000000', 'hex'))
       var string = 'compressed!'


### PR DESCRIPTION
fix #16
Added a new test for it, and all tests pass.