### PR TITLE
Support Brotli decompression (content-encoding: br)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
 - "0.12"
 - "4"
 - "5"
+- "14"
+- "16"
 language: node_js
 script: "npm run-script test-travis"
 after_script: "npm install coveralls@2.10.0 && cat ./coverage/lcov.info | coveralls"

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+Unreleased
+==================
+
+  * Add Brotli support for Node v10.16.0 and newer
 
 2.0.0 / 2016-04-09
 ==================

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Options:
 
 - `encoding` - The encoding of the stream (`gzip` or `deflate`).
   If not given, will look in `stream.headers['content-encoding']`.
+- `brotli` - [`BrotliOptions`](https://nodejs.org/api/zlib.html#class-brotlioptions) to use for Brotli decompression
 
 ## Example
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "unzip",
     "inflate",
     "zlib",
-    "gunzip"
+    "gunzip",
+    "brotli"
   ],
   "devDependencies": {
     "istanbul": "0.2.10",


### PR DESCRIPTION
Adds backwards-compatible support for Brotli decompression for versions of Node that natively support Brotli (10.16.0+). For reference, Node LTS is soon to be 14.15.0+ only.

If the version of Node doesn't support Brotli and the request specifies `content-encoding: br`, an HTTP 415 error is thrown, the exact same as before. If Node does support Brotli, it will use Brotli decompression on the provided stream.

A new option called `options.brotli` is supported. This way Brotli and Gzip options are kept separate. Only the `brotli` options are passed to the Brotli decompressor.

Added unit tests for both new and old versions of Node. Added Node 16 to the Travis CI matrix. Tested with Node 8 to ensure we get a 415 status code when Brotli is unsupported and tested with Node 16 to ensure Brotli decompression works when it is supported.